### PR TITLE
New HP Clean Modules

### DIFF
--- a/api/wo/clean.js
+++ b/api/wo/clean.js
@@ -14,6 +14,7 @@ module.exports = (parsed) => {
     let icons = []
     let links = []
     let values = []
+    let singleRows = []
     let slides = []
     let logos = []
     let products = []
@@ -266,6 +267,51 @@ module.exports = (parsed) => {
           fields: {
             title: module.fields.title,
             value: icons
+          }
+        })
+        cleanModules.push(cleanModule)
+        break;
+      case 'moduleVideoText':
+        module.fields.singleRow.forEach((row) => {
+          let cleanSingleRow = {
+            fields: {
+              imageFallback: {
+                fields: {
+                  file: {
+                    url: row.fields.imageFallback.fields.file.url
+                  }
+                }
+              },
+              video: row.fields.video,
+              videoUrl: row.fields.videoUrl,
+              text: row.fields.text,
+              alignment: row.fields.alignment,
+              icon: {
+                fields: {
+                  blueIcon: {
+                    fields: {
+                      file: {
+                        url: row.fields.icon.fields.blueIcon.fields.file.url
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          singleRows.push(cleanSingleRow)
+        })
+        cleanModule = Object.assign({}, cleanModule, {
+          sys: {
+            contentType: {
+              sys: {
+                id: 'moduleVideoText'
+              }
+            }
+          },
+          fields: {
+            helpfulTitle: module.fields.helpfulTitle,
+            singleRow: singleRows
           }
         })
         cleanModules.push(cleanModule)

--- a/api/wo/clean.js
+++ b/api/wo/clean.js
@@ -114,6 +114,22 @@ module.exports = (parsed) => {
         })
         cleanModules.push(cleanModule)
         break;
+      case 'moduleMediumHero':
+        cleanModule = Object.assign({}, cleanModule, {
+          sys: {
+            contentType: {
+              sys: {
+                id: 'moduleMediumHero'
+              }
+            }
+          },
+          fields: {
+            image: module.fields.image,
+            title: module.fields.title
+          }
+        })
+        cleanModules.push(cleanModule)
+        break;
       case 'moduleCta':
         let linkObject = null
         if (module.fields.link) {

--- a/api/wo/clean.js
+++ b/api/wo/clean.js
@@ -124,7 +124,13 @@ module.exports = (parsed) => {
             }
           },
           fields: {
-            image: module.fields.image,
+            image: {
+              fields: {
+                file: {
+                  url: module.fields.image.fields.file.url
+                }
+              }
+            },
             title: module.fields.title
           }
         })

--- a/api/wo/clean.js
+++ b/api/wo/clean.js
@@ -15,6 +15,7 @@ module.exports = (parsed) => {
     let links = []
     let values = []
     let singleRows = []
+    let highlights = []
     let slides = []
     let logos = []
     let products = []
@@ -312,6 +313,39 @@ module.exports = (parsed) => {
           fields: {
             helpfulTitle: module.fields.helpfulTitle,
             singleRow: singleRows
+          }
+        })
+        cleanModules.push(cleanModule)
+        break;
+      case 'moduleFeatureHighlights':
+        module.fields.featureHighlights.forEach((highlight) => {
+          let cleanHighlight = {
+            fields: {
+              image: {
+                fields: {
+                  file: {
+                    url: highlight.fields.image.fields.file.url
+                  }
+                }
+              },
+              video: highlight.fields.video,
+              title: highlight.fields.title,
+              description: highlight.fields.description
+            }
+          }
+          highlights.push(cleanHighlight)
+        })
+        cleanModule = Object.assign({}, cleanModule, {
+          sys: {
+            contentType: {
+              sys: {
+                id: 'moduleFeatureHighlights'
+              }
+            }
+          },
+          fields: {
+            helpfulTitle: module.fields.helpfulTitle,
+            featureHighlights: highlights
           }
         })
         cleanModules.push(cleanModule)


### PR DESCRIPTION
This PR adds entries into the switch statement for cleaning data to be displayed on the homepage. These modules are needed for the new Wool and Oak product launch, as new modules were used on the HP.

I couldn't ever get micro + ngrok up and running locally in order to verify that this 100% worked. However, I used the Contentful "Content Type" forms and previous switch statement entries to verify my nested structure. Submitting PR as the HP is already updated within Contentful. As soon as this PR is merged (and correct....), the HP should reflect the new modules.

I'll slack you about this, too.