### PR TITLE
moduleProductGrid – Adding Slug to Clean Data

### DIFF
--- a/api/wo/clean.js
+++ b/api/wo/clean.js
@@ -65,6 +65,7 @@ module.exports = (parsed) => {
             }
           },
           fields: {
+            slug: module.fields.slug,
             gridType: module.fields.gridType,
             videoModule: module.fields.videoModule,
             products: products


### PR DESCRIPTION
This PR adds the moduleProductGrid slug to the data being cleaned and delivered for that module. This is needed to properly utilize the logic set up for the CLP (All Products) nav bar functionality.

More context:
The module slug is referenced in productGrid.js in the [Wool & Oak repo](https://github.com/the-couch/wool-n-oak) on lines 390 and 510, which enables the sticky nav buttons to jump to the correct module. Without the `js-${slug}` ID, the CLP nav bar will always have to be manually coded.


Clean Data for moduleProductGrid currently:
![Screen Shot 2020-06-16 at 2 34 56 PM](https://user-images.githubusercontent.com/25212873/84820046-9b389a80-afde-11ea-844a-9b0b9788a595.png)



![Screen Shot 2020-06-16 at 2 32 04 PM](https://user-images.githubusercontent.com/25212873/84819817-4006a800-afde-11ea-9c48-f6e130cb7a6c.png)

Nav Bar `handleJump` logic:
![Screen Shot 2020-06-16 at 2 33 28 PM](https://user-images.githubusercontent.com/25212873/84819935-72180a00-afde-11ea-9327-3d2bc897115b.png)
